### PR TITLE
fix: resolve flaky integration tests

### DIFF
--- a/tests/integration/device-interaction.test.ts
+++ b/tests/integration/device-interaction.test.ts
@@ -28,11 +28,18 @@ describe.sequential('Device Interaction Tests', () => {
         logWs.on('error', reject);
       });
       
-      // Capture log messages
+      // Capture log messages - but ignore any that arrive before we start the test
+      let testStarted = false;
       logWs.on('message', (data) => {
         const log = JSON.parse(data.toString());
-        logs.push(log);
+        if (testStarted) {
+          logs.push(log);
+        }
       });
+      
+      // Wait a moment for any startup logs to pass, then start capturing
+      await new Promise(resolve => setTimeout(resolve, 100));
+      testStarted = true;
       
       try {
         const params = new URLSearchParams(DEVICE_CONFIG);


### PR DESCRIPTION
## Summary
- Clear log buffers before each test to avoid contamination from startup logs
- Ignore startup logs in device-interaction tests by delaying log capture
- Filter out INFO logs from data packet assertions in mcp-tools tests

## Test plan
- [x] Run tests locally with clean environment
- [x] Verify all tests pass consistently
- [x] No external server running during tests

🤖 Generated with [Claude Code](https://claude.ai/code)