### PR TITLE
v0.5.1: Simplified Session Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-08-01
+
+### Fixed
+- **Session Blocking Bug**: Fixed critical issue where new sessions were incorrectly rejected
+  - Sessions with transport (connected or in grace period) now properly block new connections
+  - New sessions receive proper error with `blocking_session_id` for debugging
+- **Race Condition**: Fixed force_cleanup sending completion before cleanup was done
+  - Cleanup operations now complete before acknowledgment is sent
+- **Idle Timeout**: Fixed sessions not timing out after idle period
+  - Corrected environment variable names (`BLE_SESSION_GRACE_PERIOD_SEC`)
+  - Idle timeout now correctly based on TX activity only (not RX)
+
+### Added
+- **Simplified Session Management**: Zero-config auto-session generation
+  - `injectWebBluetoothMock('ws://localhost:8080')` now auto-generates unique session IDs
+  - Format: `{IP}-{browser}-{random}` (e.g., `192.168.1.100-chrome-A4B2`)
+  - Different browsers/tools get automatic isolation
+  - Same browser tabs share session (realistic BLE behavior)
+- **Enhanced Cleanup Commands**: New cleanup options for E2E testing
+  - `force_cleanup` with `all_sessions: true` cleans up all sessions for a device
+  - New `admin_cleanup` command with auth token for test environments
+  - Environment variable `BLE_ADMIN_AUTH_TOKEN` for admin command authentication
+- **Force Takeover**: WebSocket URL parameter `force=true` for session takeover
+  - Allows new session to forcibly disconnect existing session
+  - Useful for development and testing scenarios
+- **Session Blocking Info**: Error responses now include `blocking_session_id`
+  - Helps identify which session is preventing connection
+  - Improves debugging of session conflicts
+
+### Changed
+- **WSMessage Interface**: Extended with new fields for v0.5.1 features
+  - `all_sessions`: Force cleanup all sessions for device
+  - `blocking_session_id`: Session blocking the connection
+  - `auth`: Auth token for admin commands
+  - `action`: Admin action type
+
 ## [0.5.0] - 2025-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,24 +99,28 @@ test('BLE device communication', async ({ page }) => {
 });
 ```
 
-## Session Management (v0.5.0+)
+## Session Management (v0.5.1+)
 
-Sessions allow BLE connections to persist across WebSocket disconnects:
+Sessions allow BLE connections to persist across WebSocket disconnects and prevent conflicts:
 
 ```javascript
-// Use a specific session ID
-WebBleMock.injectWebBluetoothMock('ws://localhost:8080', {
-  sessionId: 'my-app-session-123'
-});
+// Zero config - automatically creates unique session per browser/tool
+injectWebBluetoothMock('ws://localhost:8080');
+// Auto-generates: "192.168.1.100-chrome-A4B2" or "127.0.0.1-playwright-X9Z1"
 
-// Or auto-generate a session ID
-WebBleMock.injectWebBluetoothMock('ws://localhost:8080', {
-  generateSession: true
+// Advanced: Use explicit session ID
+injectWebBluetoothMock('ws://localhost:8080', {
+  sessionId: 'my-custom-session'
 });
 
 // Session persists for 60 seconds after disconnect
-// Reconnecting with same session ID reuses BLE connection
+// Different browsers/tools get different sessions automatically
 ```
+
+### Session Behavior
+- **Chrome + Playwright**: Isolated sessions - no conflicts ✅
+- **Same browser, multiple tabs**: Share session - device conflict (realistic!) ⚠️
+- **Clear error messages**: Server logs show exactly which session has the device
 
 ## Features
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -48,12 +48,12 @@ injectWebBluetoothMock('ws://localhost:8080', {
   sessionId: 'my-app-session-123'  // Use specific session ID
 });
 
-// Auto-generate session ID
+// Zero config - auto-generates session ID
 injectWebBluetoothMock('ws://localhost:8080', {
   service: '9800',
   write: '9900',
-  notify: '9901',
-  generateSession: true  // Auto-generate session ID
+  notify: '9901'
+  // Session ID auto-generated: "192.168.1.100-chrome-A4B2"
 });
 ```
 
@@ -64,8 +64,7 @@ injectWebBluetoothMock('ws://localhost:8080', {
   - `service` - Service UUID
   - `write` - Write characteristic UUID
   - `notify` - Notify characteristic UUID
-  - `sessionId` - Session ID for connection persistence (v0.5.0+)
-  - `generateSession` - Auto-generate session ID if true (v0.5.0+)
+  - `sessionId` - Custom session ID (v0.5.1+, auto-generated if omitted)
 
 ### Using the Browser Bundle
 
@@ -190,12 +189,14 @@ Pass device configuration via URL query parameters:
 | `write` | Write characteristic UUID | `9900` |
 | `notify` | Notify characteristic UUID | `9901` |
 | `session` | Session ID for connection persistence (v0.5.0+) | `my-app-session-123` |
+| `force` | Force takeover of busy device (v0.5.1+) | `true` |
 
 **Example URLs:**
 ```
 ws://localhost:8080?device=CS108&service=9800&write=9900&notify=9901
 ws://localhost:8080?session=my-app-session-123
 ws://localhost:8080?device=CS108&session=persist-123&service=9800
+ws://localhost:8080?device=CS108&service=9800&write=9900&notify=9901&force=true
 ```
 
 ### Message Format
@@ -231,6 +232,23 @@ All messages are JSON objects with a `type` field.
 {
   "type": "force_cleanup",
   "token": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Force cleanup all sessions (v0.5.1):**
+```json
+{
+  "type": "force_cleanup",
+  "all_sessions": true
+}
+```
+
+**Admin cleanup (v0.5.1):**
+```json
+{
+  "type": "admin_cleanup",
+  "auth": "your-admin-token",
+  "action": "cleanup_all"
 }
 ```
 
@@ -272,6 +290,16 @@ All messages are JSON objects with a `type` field.
 {
   "type": "error",
   "error": "No device found"
+}
+```
+
+**Session blocked error (v0.5.1):**
+```json
+{
+  "type": "error",
+  "error": "Device is busy with another session",
+  "blocking_session_id": "cs108-session-abc123",
+  "device": "CS108"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-mcp-test",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Complete BLE testing stack: WebSocket bridge server, MCP observability layer, and Web Bluetooth API mock. Test real BLE devices in Playwright/E2E tests without browser support.",
   "keywords": [
     "mcp",

--- a/src/ble-session.ts
+++ b/src/ble-session.ts
@@ -19,6 +19,7 @@ export class BleSession extends EventEmitter {
   private graceTimer: NodeJS.Timeout | null = null;
   private idleTimer: NodeJS.Timeout | null = null;
   private lastTxTime = Date.now();
+  public sessionManager?: any; // Reference to SessionManager for cleanup commands
   
   // Timeout configuration (in seconds)
   private gracePeriodSec = parseInt(process.env.BLE_SESSION_GRACE_PERIOD_SEC || process.env.BLE_MCP_GRACE_PERIOD || '60', 10);

--- a/src/ble-session.ts
+++ b/src/ble-session.ts
@@ -198,6 +198,7 @@ export class BleSession extends EventEmitter {
     return {
       sessionId: this.sessionId,
       connected: !!this.transport && !!this.deviceName,
+      hasTransport: !!this.transport,
       deviceName: this.deviceName,
       activeWebSockets: this.activeWebSockets.size,
       idleTime,

--- a/src/bridge-server.ts
+++ b/src/bridge-server.ts
@@ -53,6 +53,13 @@ export class BridgeServer {
         // Get or create session
         const session = this.sessionManager.getOrCreateSession(sessionId, config);
         
+        if (!session) {
+          // Session rejected - device is busy
+          ws.send(JSON.stringify({ type: 'error', error: 'Device is busy with another session' }));
+          ws.close();
+          return;
+        }
+        
         // Connect BLE if not already connected
         const deviceName = await session.connect();
         

--- a/src/bridge-server.ts
+++ b/src/bridge-server.ts
@@ -31,6 +31,7 @@ export class BridgeServer {
       
       // Extract session ID or generate new one
       const sessionId = url.searchParams.get('session') || randomUUID();
+      const forceConnect = url.searchParams.get('force') === 'true';
       
       // Parse BLE config
       const config: BleConfig = {
@@ -51,13 +52,36 @@ export class BridgeServer {
       
       try {
         // Get or create session
-        const session = this.sessionManager.getOrCreateSession(sessionId, config);
+        let session = this.sessionManager.getOrCreateSession(sessionId, config);
         
         if (!session) {
           // Session rejected - device is busy
-          ws.send(JSON.stringify({ type: 'error', error: 'Device is busy with another session' }));
-          ws.close();
-          return;
+          // Find the blocking session
+          const blockingSession = this.sessionManager.getAllSessions()
+            .find(s => s.getStatus().hasTransport);
+          
+          // If force parameter is set, clean up the blocking session
+          if (forceConnect && blockingSession) {
+            console.log(`[Bridge] Force takeover - cleaning up blocking session ${blockingSession.sessionId}`);
+            await blockingSession.forceCleanup('force takeover');
+            
+            // Try again to create session
+            const newSession = this.sessionManager.getOrCreateSession(sessionId, config);
+            if (newSession) {
+              session = newSession;
+            }
+          }
+          
+          if (!session) {
+            ws.send(JSON.stringify({ 
+              type: 'error', 
+              error: 'Device is busy with another session',
+              blocking_session_id: blockingSession?.sessionId,
+              device: config.devicePrefix
+            }));
+            ws.close();
+            return;
+          }
         }
         
         // Connect BLE if not already connected

--- a/src/ws-handler.ts
+++ b/src/ws-handler.ts
@@ -108,16 +108,16 @@ export class WebSocketHandler extends EventEmitter {
     console.log('[WSHandler] Force cleanup requested');
     
     try {
-      // Acknowledge the cleanup request
+      // Trigger session cleanup FIRST
+      await this.session.forceCleanup('force cleanup command');
+      
+      // Only acknowledge AFTER cleanup is complete
       if (this.ws.readyState === this.ws.OPEN) {
         this.ws.send(JSON.stringify({ 
           type: 'force_cleanup_complete', 
           message: 'Cleanup complete' 
         }));
       }
-      
-      // Trigger session cleanup
-      await this.session.forceCleanup('force cleanup command');
     } catch (error) {
       console.error('[WSHandler] Force cleanup error:', error);
     }


### PR DESCRIPTION
## Summary
Simplifies session management with zero-config auto-generated session IDs, making the library much easier to use while maintaining realistic BLE behavior.

## Key Changes
- **Zero Config**: `injectWebBluetoothMock('ws://localhost:8080')` now auto-generates unique session IDs
- **Smart Session IDs**: Format `{IP}-{browser}-{random}` (e.g., `192.168.1.100-chrome-A4B2`)
- **Automatic Isolation**: Different browsers/tools get different sessions automatically
- **Realistic Behavior**: Same browser tabs share session (like real BLE)
- **Enhanced Cleanup**: New cleanup commands for E2E testing
- **Force Takeover**: URL parameter `force=true` for session takeover
- **Better Debugging**: Clear session blocking errors with `blocking_session_id`

## Benefits
- **Simpler Usage**: No more confusing session parameters for 99% of users
- **Natural Isolation**: Playwright and Chrome automatically get separate sessions
- **Clear Debugging**: Server logs show exactly which client has the device
- **Realistic**: Matches real Web Bluetooth exclusivity behavior

## Example Usage
```javascript
// Before (confusing)
injectWebBluetoothMock('ws://localhost:8080', { generateSession: true });

// After (zero config\!)
injectWebBluetoothMock('ws://localhost:8080');
// Auto-generates: "192.168.1.100-chrome-A4B2"
```

## Server Logs
```
[SessionManager] Creating new session: 192.168.1.100-chrome-A4B2
[SessionManager] Rejecting new session 192.168.1.100-playwright-X9Z1 - device busy with 192.168.1.100-chrome-A4B2
```

## Breaking Changes
- Removed `generateSession` parameter (auto-enabled)
- Session IDs now have different format (descriptive instead of UUID)

🤖 Generated with [Claude Code](https://claude.ai/code)