### PR TITLE
feat: cache busting, version checking, and session persistence improvements (v0.5.3)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,59 @@
+# ble-mcp-test Examples
+
+This directory contains examples and test utilities for the ble-mcp-test library.
+
+## Cache Busting Test (version-check.html)
+
+Tests the cache-busting functionality of the web bundle:
+- Load bundle with version suffix (recommended)
+- Load bundle with timestamp query parameter
+- Check loaded version against expected version
+
+**Usage:**
+```bash
+# Start a local server
+python3 -m http.server 8000
+# Open http://localhost:8000/examples/version-check.html
+```
+
+## Session Persistence Test (minimal-session-repro.html)
+
+Minimal reproduction for testing session ID persistence across page reloads.
+
+**Requirements:**
+- WebSocket bridge server must be running on localhost:8080
+
+**Usage:**
+```bash
+# Start the bridge server
+pnpm run start
+
+# In another terminal, start a local server
+python3 -m http.server 8000
+# Open http://localhost:8000/examples/minimal-session-repro.html
+```
+
+**Steps to test:**
+1. Click "Inject Mock" to initialize the Web Bluetooth mock
+2. Click "Show Session Info" to see current session details
+3. Click "Connect Device" to attempt connection (requires bridge server)
+4. Click "Reload Page" to test session persistence
+5. Repeat steps 1-3 to verify session is reused
+
+## Session Persistence Demo (session-persistence-demo.js)
+
+Node.js script demonstrating session persistence functionality.
+
+**Usage:**
+```bash
+node examples/session-persistence-demo.js
+```
+
+## Force Cleanup Examples
+
+Examples demonstrating the force cleanup functionality for stuck sessions:
+- `force-cleanup-simple.html` - Interactive HTML test
+- `force-cleanup-example.js` - Node.js example
+- `force-cleanup-playwright.ts` - Playwright test example
+
+All force cleanup examples require the bridge server to be running.

--- a/examples/minimal-session-repro.html
+++ b/examples/minimal-session-repro.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Minimal Session Bug Reproduction</title>
+    <style>
+        body { font-family: monospace; padding: 20px; }
+        button { margin: 10px; padding: 10px; }
+        #log { border: 1px solid #ccc; padding: 10px; margin: 10px 0; height: 400px; overflow-y: auto; }
+        .error { color: red; }
+        .success { color: green; }
+        .info { color: blue; }
+    </style>
+</head>
+<body>
+    <h1>Minimal Session Bug Reproduction</h1>
+    
+    <button id="inject">1. Inject Mock</button>
+    <button id="showSession">2. Show Session Info</button>
+    <button id="connect">3. Connect Device</button>
+    <button id="disconnect">4. Disconnect</button>
+    <button id="reload">5. Reload Page</button>
+    <button id="clear">Clear Log</button>
+    
+    <div id="log"></div>
+
+    <script src="../dist/web-ble-mock.bundle.js"></script>
+    <script>
+        const log = document.getElementById('log');
+        let device = null;
+        let connectionCount = 0;
+
+        function addLog(message, type = '') {
+            const entry = document.createElement('div');
+            entry.className = type;
+            entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+            log.appendChild(entry);
+            log.scrollTop = log.scrollHeight;
+        }
+
+        // Override console.log to capture MockBluetooth logs
+        const originalLog = console.log;
+        console.log = function(...args) {
+            const message = args.join(' ');
+            if (message.includes('[MockBluetooth]') || 
+                message.includes('[MockGATT]') || 
+                message.includes('[WebSocket]')) {
+                addLog(message, 'info');
+            }
+            originalLog.apply(console, args);
+        };
+
+        // Check localStorage on page load
+        window.addEventListener('DOMContentLoaded', () => {
+            const storedSession = localStorage.getItem('ble-mock-session-id');
+            if (storedSession) {
+                addLog(`Page loaded with existing session in localStorage: ${storedSession}`, 'info');
+            } else {
+                addLog('Page loaded with no existing session in localStorage');
+            }
+        });
+
+        document.getElementById('inject').onclick = () => {
+            try {
+                // Inject the mock - this is what happens on page load in the user's scenario
+                window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+                addLog('Mock injected successfully', 'success');
+                
+                // Show what session was created/reused
+                if (navigator.bluetooth && navigator.bluetooth.autoSessionId) {
+                    addLog(`AutoSessionId in MockBluetooth: ${navigator.bluetooth.autoSessionId}`, 'info');
+                }
+            } catch (error) {
+                addLog(`Injection error: ${error.message}`, 'error');
+            }
+        };
+
+        document.getElementById('showSession').onclick = () => {
+            try {
+                const storedSession = localStorage.getItem('ble-mock-session-id');
+                const autoSession = navigator.bluetooth?.autoSessionId;
+                
+                addLog('=== Session Information ===');
+                addLog(`localStorage['ble-mock-session-id']: ${storedSession || 'null'}`);
+                addLog(`navigator.bluetooth.autoSessionId: ${autoSession || 'undefined'}`);
+                
+                if (device) {
+                    addLog(`device.sessionId: ${device.sessionId || 'undefined'}`);
+                    addLog(`device.bleConfig: ${JSON.stringify(device.bleConfig || {})}`);
+                }
+            } catch (error) {
+                addLog(`Error showing session: ${error.message}`, 'error');
+            }
+        };
+
+        document.getElementById('connect').onclick = async () => {
+            try {
+                connectionCount++;
+                addLog(`=== Connection Attempt #${connectionCount} ===`);
+                
+                // Request device
+                addLog('Requesting device...');
+                device = await navigator.bluetooth.requestDevice({
+                    filters: [{ namePrefix: 'CS108' }]
+                });
+                
+                addLog(`Got device: ${device.id}`);
+                addLog(`Device sessionId: ${device.sessionId || 'undefined'}`);
+                
+                // Connect GATT
+                addLog('Connecting GATT...');
+                
+                // Capture WebSocket URL by overriding temporarily
+                const OriginalWebSocket = WebSocket;
+                let capturedUrl = null;
+                window.WebSocket = class extends OriginalWebSocket {
+                    constructor(url, ...args) {
+                        capturedUrl = url;
+                        super(url, ...args);
+                    }
+                };
+                
+                await device.gatt.connect();
+                
+                // Restore WebSocket
+                window.WebSocket = OriginalWebSocket;
+                
+                addLog('Connected successfully!', 'success');
+                
+                if (capturedUrl) {
+                    const urlObj = new URL(capturedUrl);
+                    const sessionParam = urlObj.searchParams.get('session');
+                    addLog(`WebSocket URL session parameter: ${sessionParam}`, 'info');
+                    
+                    // Check if it matches localStorage
+                    const storedSession = localStorage.getItem('ble-mock-session-id');
+                    if (storedSession && sessionParam !== storedSession) {
+                        addLog(`🐛 BUG: WebSocket session (${sessionParam}) != localStorage session (${storedSession})`, 'error');
+                    }
+                }
+                
+            } catch (error) {
+                addLog(`Connection error: ${error.message}`, 'error');
+            }
+        };
+
+        document.getElementById('disconnect').onclick = async () => {
+            if (device && device.gatt.connected) {
+                addLog('Disconnecting...');
+                await device.gatt.disconnect();
+                addLog('Disconnected', 'success');
+            } else {
+                addLog('No device connected', 'error');
+            }
+        };
+
+        document.getElementById('reload').onclick = () => {
+            addLog('Reloading page...');
+            setTimeout(() => window.location.reload(), 100);
+        };
+
+        document.getElementById('clear').onclick = () => {
+            log.innerHTML = '';
+        };
+    </script>
+</body>
+</html>

--- a/examples/session-persistence-test.html
+++ b/examples/session-persistence-test.html
@@ -1,0 +1,647 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BLE Mock - Session Persistence Test</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .container {
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+        }
+        .step {
+            background: white;
+            border-left: 4px solid #007bff;
+            padding: 15px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .result {
+            background: #d4edda;
+            border: 1px solid #c3e6cb;
+            color: #155724;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+            font-family: monospace;
+            white-space: pre-wrap;
+        }
+        .error {
+            background: #f8d7da;
+            border: 1px solid #f5c6cb;
+            color: #721c24;
+        }
+        button {
+            background: #007bff;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+        }
+        button:hover {
+            background: #0056b3;
+        }
+        button:disabled {
+            background: #6c757d;
+            cursor: not-allowed;
+        }
+        .info {
+            background: #d1ecf1;
+            border: 1px solid #bee5eb;
+            color: #0c5460;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        .warning {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            color: #856404;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        .success {
+            background: #d4edda;
+            border: 1px solid #c3e6cb;
+            color: #155724;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        code {
+            background: #f8f9fa;
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        }
+    </style>
+</head>
+<body>
+    <h1>🧪 BLE Mock - Session Persistence Test</h1>
+    
+    <div class="info">
+        <h3>📋 What This Tests</h3>
+        <p>This page demonstrates localStorage session persistence in the BLE mock. Session IDs should persist across:</p>
+        <ul>
+            <li><strong>Page reloads</strong> - Same session ID after F5/Ctrl+R</li>
+            <li><strong>Browser restarts</strong> - Session persists after closing/reopening browser</li>
+            <li><strong>Multiple injections</strong> - Calling injectWebBluetoothMock() multiple times</li>
+            <li><strong>Browser tabs</strong> - Same domain shares session ID</li>
+        </ul>
+    </div>
+    
+    <div class="container">
+        <h2>🔄 Page Refresh Test</h2>
+        <div class="warning">
+            <p><strong>To test page refresh persistence:</strong></p>
+            <ol>
+                <li>Click "Initialize Session" below</li>
+                <li>Note the session ID displayed</li>
+                <li>Refresh this page (F5 or Ctrl+R)</li>
+                <li>Click "Check Existing Session"</li>
+                <li>Verify the session ID is the same</li>
+            </ol>
+        </div>
+        
+        <button onclick="initializeSession()">Initialize Session</button>
+        <button onclick="checkExistingSession()">Check Existing Session</button>
+        <button onclick="showStorageInfo()">Show Storage Info</button>
+        <button onclick="runPersistenceTest()">🧪 Test localStorage Support</button>
+        <div id="refreshTestResult"></div>
+    </div>
+
+    <div class="container">
+        <h2>🔍 Test Steps</h2>
+        
+        <div class="step">
+            <h3>Step 1: Clear existing session</h3>
+            <p>Remove any stored session from localStorage</p>
+            <button onclick="clearSession()">Clear Session</button>
+            <div id="clearResult"></div>
+        </div>
+
+        <div class="step">
+            <h3>Step 2: First injection</h3>
+            <p>Inject the mock and check what session ID is generated/stored</p>
+            <button onclick="firstInjection()">First Injection</button>
+            <div id="firstResult"></div>
+        </div>
+
+        <div class="step">
+            <h3>Step 3: Second injection</h3>
+            <p>Inject again (simulating page reload) and verify same session ID is reused</p>
+            <button onclick="secondInjection()">Second Injection</button>
+            <div id="secondResult"></div>
+        </div>
+
+        <div class="step">
+            <h3>Step 4: WebSocket connection test</h3>
+            <p>Connect to device and verify WebSocket uses the correct session ID</p>
+            <button onclick="testWebSocketConnection()">Test WebSocket Connection</button>
+            <div id="connectionResult"></div>
+        </div>
+
+        <div class="step">
+            <h3>Step 5: Full verification</h3>
+            <p>Run complete test to verify all session IDs match</p>
+            <button onclick="runFullTest()">Run Full Test</button>
+            <div id="fullTestResult"></div>
+        </div>
+    </div>
+
+    <div class="container">
+        <h2>🔧 Troubleshooting</h2>
+        
+        <div class="warning">
+            <h4>⚠️ Common Issues</h4>
+            <ul>
+                <li><strong>Different session IDs:</strong> Check if localStorage is disabled or blocked</li>
+                <li><strong>Session not persisting:</strong> Verify you're on the same domain/origin</li>
+                <li><strong>Private browsing:</strong> localStorage may be restricted in incognito mode</li>
+                <li><strong>Test frameworks:</strong> Some frameworks clear localStorage between tests</li>
+            </ul>
+        </div>
+
+        <div class="info">
+            <h4>🛠️ Manual Checks</h4>
+            <p>You can manually inspect localStorage:</p>
+            <ul>
+                <li>Open DevTools (F12)</li>
+                <li>Go to Application/Storage tab</li>
+                <li>Check localStorage for key: <code>ble-mock-session-id</code></li>
+                <li>Session format: <code>IP-browser-XXXX</code></li>
+            </ul>
+        </div>
+    </div>
+
+    <script src="../dist/web-ble-mock.bundle.js"></script>
+    <script>
+        let capturedWebSocketUrls = [];
+        let firstSessionId = null;
+        let secondSessionId = null;
+        
+        // Store test history in localStorage for refresh persistence
+        const TEST_HISTORY_KEY = 'ble-test-history';
+        
+        function getTestHistory() {
+            try {
+                return JSON.parse(localStorage.getItem(TEST_HISTORY_KEY) || '[]');
+            } catch {
+                return [];
+            }
+        }
+        
+        function addToTestHistory(entry) {
+            const history = getTestHistory();
+            history.push({
+                ...entry,
+                timestamp: new Date().toISOString()
+            });
+            localStorage.setItem(TEST_HISTORY_KEY, JSON.stringify(history));
+        }
+        
+        function clearTestHistory() {
+            localStorage.removeItem(TEST_HISTORY_KEY);
+        }
+        
+        function initializeSession() {
+            clearResults('refreshTestResult');
+            try {
+                // Use mock WebSocket
+                window.WebSocket = window.MockWebSocket;
+                
+                // Clear any existing session first
+                window.WebBleMock.clearStoredSession();
+                clearTestHistory();
+                
+                // Initialize new session
+                window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+                
+                const bluetooth = navigator.bluetooth;
+                const sessionId = bluetooth.autoSessionId;
+                const stored = localStorage.getItem('ble-mock-session-id');
+                
+                // Record this initialization
+                addToTestHistory({
+                    action: 'initialize',
+                    sessionId: sessionId,
+                    stored: stored,
+                    pageLoad: performance.now()
+                });
+                
+                log('refreshTestResult', `🆕 NEW SESSION INITIALIZED`);
+                log('refreshTestResult', `Session ID: ${sessionId}`);
+                log('refreshTestResult', `Stored in localStorage: ${stored}`);
+                log('refreshTestResult', `Time: ${new Date().toLocaleTimeString()}`);
+                log('refreshTestResult', '');
+                log('refreshTestResult', '✅ Now refresh this page (F5) and click "Check Existing Session"');
+                
+            } catch (error) {
+                log('refreshTestResult', `❌ Error initializing session: ${error.message}`, true);
+            }
+        }
+        
+        function checkExistingSession() {
+            clearResults('refreshTestResult');
+            try {
+                const storedSession = localStorage.getItem('ble-mock-session-id');
+                const history = getTestHistory();
+                
+                if (!storedSession) {
+                    log('refreshTestResult', '❌ No session found in localStorage');
+                    log('refreshTestResult', 'Click "Initialize Session" first');
+                    return;
+                }
+                
+                // Re-inject the mock to see if it reuses the session
+                window.WebSocket = window.MockWebSocket;
+                window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+                
+                const bluetooth = navigator.bluetooth;
+                const currentSessionId = bluetooth.autoSessionId;
+                
+                // Record this check
+                addToTestHistory({
+                    action: 'check',
+                    sessionId: currentSessionId,
+                    stored: storedSession,
+                    pageLoad: performance.now()
+                });
+                
+                log('refreshTestResult', `🔍 CHECKING EXISTING SESSION`);
+                log('refreshTestResult', `Found in localStorage: ${storedSession}`);
+                log('refreshTestResult', `Current session ID: ${currentSessionId}`);
+                log('refreshTestResult', `Time: ${new Date().toLocaleTimeString()}`);
+                log('refreshTestResult', '');
+                
+                if (currentSessionId === storedSession) {
+                    log('refreshTestResult', '🎉 SUCCESS! Session persisted across page refresh!');
+                    log('refreshTestResult', '✅ localStorage persistence is working correctly');
+                } else {
+                    log('refreshTestResult', '❌ FAILED! Session ID changed after refresh', true);
+                    log('refreshTestResult', 'This indicates a localStorage persistence issue', true);
+                }
+                
+                // Show history
+                if (history.length > 1) {
+                    log('refreshTestResult', '');
+                    log('refreshTestResult', '📜 TEST HISTORY:');
+                    history.forEach((entry, i) => {
+                        const time = new Date(entry.timestamp).toLocaleTimeString();
+                        log('refreshTestResult', `${i + 1}. ${entry.action}: ${entry.sessionId} at ${time}`);
+                    });
+                }
+                
+            } catch (error) {
+                log('refreshTestResult', `❌ Error checking session: ${error.message}`, true);
+            }
+        }
+        
+        function showStorageInfo() {
+            clearResults('refreshTestResult');
+            
+            const storedSession = localStorage.getItem('ble-mock-session-id');
+            const history = getTestHistory();
+            
+            log('refreshTestResult', '💾 LOCALSTORAGE INFORMATION');
+            log('refreshTestResult', '');
+            log('refreshTestResult', `Current session: ${storedSession || 'None'}`);
+            log('refreshTestResult', `History entries: ${history.length}`);
+            log('refreshTestResult', `Page loaded at: ${new Date().toLocaleTimeString()}`);
+            log('refreshTestResult', '');
+            
+            // Show raw localStorage contents
+            log('refreshTestResult', '🔍 Raw localStorage contents:');
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i);
+                if (key && key.startsWith('ble-')) {
+                    const value = localStorage.getItem(key);
+                    log('refreshTestResult', `  ${key}: ${value}`);
+                }
+            }
+            
+            if (history.length > 0) {
+                log('refreshTestResult', '');
+                log('refreshTestResult', '📊 Test history:');
+                history.forEach((entry, i) => {
+                    const time = new Date(entry.timestamp).toLocaleTimeString();
+                    log('refreshTestResult', `  ${i + 1}. ${entry.action}: ${entry.sessionId} (${time})`);
+                });
+            }
+        }
+        
+        function runPersistenceTest() {
+            clearResults('refreshTestResult');
+            
+            try {
+                const testResult = window.WebBleMock.testSessionPersistence();
+                
+                log('refreshTestResult', '🧪 LOCALSTORAGE PERSISTENCE TEST');
+                log('refreshTestResult', '');
+                log('refreshTestResult', `Overall result: ${testResult.testResult.toUpperCase()}`);
+                log('refreshTestResult', '');
+                
+                testResult.details.forEach(detail => {
+                    log('refreshTestResult', detail);
+                });
+                
+                if (testResult.testResult === 'pass') {
+                    log('refreshTestResult', '');
+                    log('refreshTestResult', '🎉 localStorage is working correctly!');
+                    log('refreshTestResult', '✅ Session persistence should work properly');
+                } else if (testResult.testResult === 'no-storage') {
+                    log('refreshTestResult', '');
+                    log('refreshTestResult', '❌ localStorage is not available');
+                    log('refreshTestResult', 'Session persistence will not work in this environment', true);
+                } else {
+                    log('refreshTestResult', '');
+                    log('refreshTestResult', '⚠️ localStorage has issues');
+                    log('refreshTestResult', 'Session persistence may not work reliably', true);
+                }
+                
+                // Show environment info
+                log('refreshTestResult', '');
+                log('refreshTestResult', '🌐 Environment info:');
+                log('refreshTestResult', `  User Agent: ${navigator.userAgent}`);
+                log('refreshTestResult', `  Origin: ${window.location.origin}`);
+                log('refreshTestResult', `  Protocol: ${window.location.protocol}`);
+                
+            } catch (error) {
+                log('refreshTestResult', `❌ Error running persistence test: ${error.message}`, true);
+            }
+        }
+
+        // Mock WebSocket to capture URLs without actually connecting
+        const OriginalWebSocket = WebSocket;
+        window.MockWebSocket = class {
+            constructor(url) {
+                this.url = url;
+                capturedWebSocketUrls.push(url);
+                this.readyState = WebSocket.CONNECTING;
+                
+                // Simulate successful connection after a delay
+                setTimeout(() => {
+                    this.readyState = WebSocket.OPEN;
+                    if (this.onopen) {
+                        this.onopen(new Event('open'));
+                    }
+                    if (this.onmessage) {
+                        this.onmessage(new MessageEvent('message', {
+                            data: JSON.stringify({ type: 'connected', token: 'test-token' })
+                        }));
+                    }
+                }, 100);
+            }
+            
+            send(data) {
+                console.log('Mock WebSocket send:', data);
+            }
+            
+            close() {
+                this.readyState = WebSocket.CLOSED;
+                if (this.onclose) {
+                    this.onclose(new CloseEvent('close'));
+                }
+            }
+            
+            addEventListener(event, handler) {
+                this[`on${event}`] = handler;
+            }
+        };
+
+        function log(elementId, message, isError = false) {
+            const element = document.getElementById(elementId);
+            const resultDiv = document.createElement('div');
+            resultDiv.className = isError ? 'result error' : 'result';
+            resultDiv.textContent = message;
+            element.appendChild(resultDiv);
+        }
+
+        function clearResults(elementId) {
+            document.getElementById(elementId).innerHTML = '';
+        }
+
+        function clearSession() {
+            clearResults('clearResult');
+            try {
+                window.WebBleMock.clearStoredSession();
+                const stored = localStorage.getItem('ble-mock-session-id');
+                if (stored) {
+                    log('clearResult', `❌ Session still exists: ${stored}`, true);
+                } else {
+                    log('clearResult', '✅ Session cleared successfully');
+                }
+            } catch (error) {
+                log('clearResult', `❌ Error clearing session: ${error.message}`, true);
+            }
+        }
+
+        function firstInjection() {
+            clearResults('firstResult');
+            try {
+                // Use mock WebSocket to avoid actual connections
+                window.WebSocket = window.MockWebSocket;
+                
+                window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+                
+                const bluetooth = navigator.bluetooth;
+                firstSessionId = bluetooth.autoSessionId;
+                const stored = localStorage.getItem('ble-mock-session-id');
+                
+                log('firstResult', `Generated session ID: ${firstSessionId}`);
+                log('firstResult', `Stored in localStorage: ${stored}`);
+                log('firstResult', `IDs match: ${firstSessionId === stored ? '✅ Yes' : '❌ No'}`);
+                
+                if (firstSessionId && firstSessionId === stored) {
+                    log('firstResult', '✅ First injection successful');
+                } else {
+                    log('firstResult', '❌ Session ID mismatch or not stored', true);
+                }
+            } catch (error) {
+                log('firstResult', `❌ Error in first injection: ${error.message}`, true);
+            }
+        }
+
+        function secondInjection() {
+            clearResults('secondResult');
+            try {
+                window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+                
+                const bluetooth = navigator.bluetooth;
+                secondSessionId = bluetooth.autoSessionId;
+                const stored = localStorage.getItem('ble-mock-session-id');
+                
+                log('secondResult', `Reused session ID: ${secondSessionId}`);
+                log('secondResult', `Stored in localStorage: ${stored}`);
+                log('secondResult', `Matches first injection: ${firstSessionId === secondSessionId ? '✅ Yes' : '❌ No'}`);
+                log('secondResult', `Matches localStorage: ${secondSessionId === stored ? '✅ Yes' : '❌ No'}`);
+                
+                if (firstSessionId && secondSessionId === firstSessionId && secondSessionId === stored) {
+                    log('secondResult', '✅ Session persistence working correctly');
+                } else {
+                    log('secondResult', '❌ Session not persisted correctly', true);
+                }
+            } catch (error) {
+                log('secondResult', `❌ Error in second injection: ${error.message}`, true);
+            }
+        }
+
+        async function testWebSocketConnection() {
+            clearResults('connectionResult');
+            try {
+                if (!navigator.bluetooth) {
+                    log('connectionResult', '❌ No bluetooth mock injected. Run injections first.', true);
+                    return;
+                }
+
+                // Clear captured URLs
+                capturedWebSocketUrls = [];
+                
+                const device = await navigator.bluetooth.requestDevice({
+                    filters: [{ namePrefix: 'CS108' }]
+                });
+                
+                log('connectionResult', `Device session ID: ${device.sessionId}`);
+                
+                await device.gatt.connect();
+                
+                if (capturedWebSocketUrls.length > 0) {
+                    const url = capturedWebSocketUrls[capturedWebSocketUrls.length - 1];
+                    log('connectionResult', `WebSocket URL: ${url}`);
+                    
+                    const urlObj = new URL(url);
+                    const sessionParam = urlObj.searchParams.get('session');
+                    
+                    log('connectionResult', `Session parameter: ${sessionParam}`);
+                    log('connectionResult', `Matches device session: ${device.sessionId === sessionParam ? '✅ Yes' : '❌ No'}`);
+                    log('connectionResult', `Matches stored session: ${sessionParam === localStorage.getItem('ble-mock-session-id') ? '✅ Yes' : '❌ No'}`);
+                    
+                    if (device.sessionId === sessionParam && sessionParam === localStorage.getItem('ble-mock-session-id')) {
+                        log('connectionResult', '✅ WebSocket using correct session ID');
+                    } else {
+                        log('connectionResult', '❌ WebSocket session ID mismatch', true);
+                    }
+                } else {
+                    log('connectionResult', '❌ No WebSocket connection captured', true);
+                }
+                
+            } catch (error) {
+                log('connectionResult', `❌ Error testing WebSocket: ${error.message}`, true);
+            }
+        }
+
+        async function runFullTest() {
+            clearResults('fullTestResult');
+            
+            log('fullTestResult', '🧪 Running complete session persistence test...');
+            log('fullTestResult', '');
+            
+            // Step 1: Clear
+            window.WebBleMock.clearStoredSession();
+            log('fullTestResult', '1️⃣ Cleared existing session');
+            
+            // Step 2: First injection
+            window.WebSocket = window.MockWebSocket;
+            capturedWebSocketUrls = [];
+            
+            window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+            const firstId = navigator.bluetooth.autoSessionId;
+            const storedAfterFirst = localStorage.getItem('ble-mock-session-id');
+            
+            log('fullTestResult', `2️⃣ First injection: ${firstId}`);
+            log('fullTestResult', `   Stored: ${storedAfterFirst}`);
+            
+            // Step 3: Connect to capture WebSocket URL
+            const device1 = await navigator.bluetooth.requestDevice({ filters: [{ namePrefix: 'CS108' }] });
+            await device1.gatt.connect();
+            const firstUrl = capturedWebSocketUrls[capturedWebSocketUrls.length - 1];
+            const firstUrlSession = new URL(firstUrl).searchParams.get('session');
+            
+            log('fullTestResult', `   WebSocket session: ${firstUrlSession}`);
+            
+            // Step 4: Second injection
+            window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+            const secondId = navigator.bluetooth.autoSessionId;
+            const storedAfterSecond = localStorage.getItem('ble-mock-session-id');
+            
+            log('fullTestResult', `3️⃣ Second injection: ${secondId}`);
+            log('fullTestResult', `   Stored: ${storedAfterSecond}`);
+            
+            // Step 5: Connect again
+            const device2 = await navigator.bluetooth.requestDevice({ filters: [{ namePrefix: 'CS108' }] });
+            await device2.gatt.connect();
+            const secondUrl = capturedWebSocketUrls[capturedWebSocketUrls.length - 1];
+            const secondUrlSession = new URL(secondUrl).searchParams.get('session');
+            
+            log('fullTestResult', `   WebSocket session: ${secondUrlSession}`);
+            log('fullTestResult', '');
+            
+            // Verification
+            const allMatch = firstId === secondId && 
+                           firstId === storedAfterFirst && 
+                           firstId === storedAfterSecond &&
+                           firstId === firstUrlSession && 
+                           firstId === secondUrlSession;
+            
+            if (allMatch) {
+                log('fullTestResult', '🎉 ALL CHECKS PASSED!');
+                log('fullTestResult', '✅ Session IDs are consistent across all operations');
+                log('fullTestResult', '✅ localStorage persistence is working correctly');
+                log('fullTestResult', '✅ WebSocket connections use the correct session ID');
+            } else {
+                log('fullTestResult', '❌ SOME CHECKS FAILED:');
+                log('fullTestResult', `   First == Second: ${firstId === secondId ? '✅' : '❌'}`);
+                log('fullTestResult', `   First == Stored1: ${firstId === storedAfterFirst ? '✅' : '❌'}`);
+                log('fullTestResult', `   First == Stored2: ${firstId === storedAfterSecond ? '✅' : '❌'}`);
+                log('fullTestResult', `   First == URL1: ${firstId === firstUrlSession ? '✅' : '❌'}`);
+                log('fullTestResult', `   First == URL2: ${firstId === secondUrlSession ? '✅' : '❌'}`);
+            }
+            
+            // Restore WebSocket
+            window.WebSocket = OriginalWebSocket;
+        }
+
+        // Show localStorage availability and session status on page load
+        window.addEventListener('DOMContentLoaded', function() {
+            if (typeof localStorage === 'undefined') {
+                document.body.insertAdjacentHTML('afterbegin', 
+                    '<div class="error"><strong>⚠️ localStorage not available!</strong> This test requires localStorage support.</div>'
+                );
+            } else {
+                const stored = localStorage.getItem('ble-mock-session-id');
+                const history = getTestHistory();
+                
+                if (stored) {
+                    const lastEntry = history[history.length - 1];
+                    const wasRefresh = history.some(entry => entry.action === 'initialize');
+                    
+                    let message = `<strong>💾 Existing session found:</strong> ${stored}`;
+                    if (wasRefresh) {
+                        message += `<br><strong>🔄 This appears to be after a page refresh!</strong> Click "Check Existing Session" to verify persistence.`;
+                    }
+                    
+                    document.body.insertAdjacentHTML('afterbegin', 
+                        `<div class="success">${message}</div>`
+                    );
+                } else if (history.length > 0) {
+                    document.body.insertAdjacentHTML('afterbegin', 
+                        '<div class="warning"><strong>⚠️ Test history found but no session!</strong> This may indicate a localStorage issue.</div>'
+                    );
+                }
+            }
+        });
+    </script>
+</body>
+</html>

--- a/examples/version-check.html
+++ b/examples/version-check.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Bundle Version Check</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; max-width: 800px; margin: 0 auto; }
+        .success { color: green; }
+        .error { color: red; }
+        .warning { color: orange; }
+        pre { background: #f5f5f5; padding: 10px; border-radius: 4px; }
+        button { padding: 10px 20px; margin: 5px; }
+    </style>
+</head>
+<body>
+    <h1>ble-mcp-test Bundle Version Check</h1>
+    
+    <h2>1. Load Bundle with Cache Busting</h2>
+    <button onclick="loadWithVersion()">Load Versioned Bundle</button>
+    <button onclick="loadWithTimestamp()">Load with Timestamp</button>
+    <button onclick="loadWithoutCache()">Load without Cache</button>
+    
+    <h2>2. Check Loaded Version</h2>
+    <button onclick="checkVersion()">Check Version</button>
+    <button onclick="compareVersions()">Compare with package.json</button>
+    
+    <h2>3. Force Reload</h2>
+    <button onclick="forceReload()">Force Reload Bundle</button>
+    
+    <div id="output"></div>
+    
+    <script>
+        const output = document.getElementById('output');
+        const EXPECTED_VERSION = '0.5.3'; // Update this when testing new versions
+        
+        function log(message, className = '') {
+            const div = document.createElement('div');
+            div.className = className;
+            div.innerHTML = message;
+            output.appendChild(div);
+        }
+        
+        function clearLog() {
+            output.innerHTML = '';
+        }
+        
+        function loadWithVersion() {
+            clearLog();
+            const script = document.createElement('script');
+            script.src = `../dist/web-ble-mock.bundle.v${EXPECTED_VERSION}.js`;
+            script.onload = () => {
+                log(`✅ Loaded versioned bundle: v${EXPECTED_VERSION}`, 'success');
+                checkVersion();
+            };
+            script.onerror = () => {
+                log(`❌ Failed to load versioned bundle`, 'error');
+            };
+            document.head.appendChild(script);
+        }
+        
+        function loadWithTimestamp() {
+            clearLog();
+            const script = document.createElement('script');
+            script.src = `../dist/web-ble-mock.bundle.js?t=${Date.now()}`;
+            script.onload = () => {
+                log(`✅ Loaded bundle with timestamp query`, 'success');
+                checkVersion();
+            };
+            script.onerror = () => {
+                log(`❌ Failed to load bundle`, 'error');
+            };
+            document.head.appendChild(script);
+        }
+        
+        function loadWithoutCache() {
+            clearLog();
+            
+            // Remove existing script if any
+            const existing = document.querySelector('script[src*="web-ble-mock.bundle"]');
+            if (existing) {
+                existing.remove();
+            }
+            
+            // Create new script with cache-busting headers
+            const script = document.createElement('script');
+            script.src = `../dist/web-ble-mock.bundle.js?nocache=${Math.random()}`;
+            script.setAttribute('data-cache', 'no-store');
+            
+            script.onload = () => {
+                log(`✅ Loaded bundle with cache busting`, 'success');
+                checkVersion();
+            };
+            script.onerror = () => {
+                log(`❌ Failed to load bundle`, 'error');
+            };
+            
+            document.head.appendChild(script);
+        }
+        
+        function checkVersion() {
+            log('<h3>Version Check Results:</h3>');
+            
+            if (typeof window.WebBleMock === 'undefined') {
+                log('❌ WebBleMock not loaded!', 'error');
+                return;
+            }
+            
+            log(`✅ WebBleMock loaded`, 'success');
+            log(`Available functions: ${Object.keys(window.WebBleMock).join(', ')}`);
+            
+            if (window.WebBleMock.version) {
+                log(`Bundle version: <strong>${window.WebBleMock.version}</strong>`, 'success');
+                
+                if (window.WebBleMock.version === EXPECTED_VERSION) {
+                    log(`✅ Version matches expected: ${EXPECTED_VERSION}`, 'success');
+                } else {
+                    log(`⚠️ Version mismatch! Expected ${EXPECTED_VERSION}, got ${window.WebBleMock.version}`, 'warning');
+                    log(`This might indicate a cached bundle is being used.`, 'warning');
+                }
+            } else {
+                log('❌ No version property found - using old bundle!', 'error');
+            }
+            
+            // Also check the function
+            if (window.WebBleMock.getBundleVersion) {
+                const funcVersion = window.WebBleMock.getBundleVersion();
+                log(`getBundleVersion() returns: ${funcVersion}`);
+            }
+        }
+        
+        function compareVersions() {
+            // In real usage, you'd fetch package.json or have the version injected
+            log('<h3>Version Comparison:</h3>');
+            log(`Expected version (from code): ${EXPECTED_VERSION}`);
+            
+            if (window.WebBleMock?.version) {
+                log(`Loaded bundle version: ${window.WebBleMock.version}`);
+                
+                const match = window.WebBleMock.version === EXPECTED_VERSION;
+                log(match ? '✅ Versions match!' : '❌ Version mismatch - cache issue likely!', match ? 'success' : 'error');
+                
+                if (!match) {
+                    log('<h4>Recommended Actions:</h4>');
+                    log('1. Clear browser cache (Ctrl+Shift+R or Cmd+Shift+R)');
+                    log('2. Use versioned bundle URL: web-ble-mock.bundle.v' + EXPECTED_VERSION + '.js');
+                    log('3. Add timestamp query param: ?t=' + Date.now());
+                    log('4. Check Network tab for 304 (Not Modified) responses');
+                }
+            } else {
+                log('❌ No version found in loaded bundle', 'error');
+            }
+        }
+        
+        function forceReload() {
+            clearLog();
+            
+            // Remove all existing bundle scripts
+            document.querySelectorAll('script[src*="web-ble-mock.bundle"]').forEach(s => s.remove());
+            
+            // Clear the global
+            delete window.WebBleMock;
+            
+            log('🔄 Cleared existing bundle', 'warning');
+            log('Click one of the load buttons above to reload');
+        }
+        
+        // Check on page load
+        window.addEventListener('DOMContentLoaded', () => {
+            if (window.WebBleMock) {
+                log('<h3>Bundle already loaded on page load:</h3>');
+                checkVersion();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-mcp-test",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Complete BLE testing stack: WebSocket bridge server, MCP observability layer, and Web Bluetooth API mock. Test real BLE devices in Playwright/E2E tests without browser support.",
   "keywords": [
     "mcp",

--- a/prp/prompt/session-manager-fixes.md
+++ b/prp/prompt/session-manager-fixes.md
@@ -1,0 +1,402 @@
+name: "Session Manager Fixes and Cache Busting Implementation v0.5.3 (Enhanced Bug Investigation)"
+description: |
+  Complete session management fixes with deep investigation of the session ID regeneration bug, implement cache busting, add version checking capabilities, and provide minimal end-to-end test for deployment validation.
+
+## Goal
+Fix the critical session ID bug where console logs show correct session reuse but WebSocket connects with a different session, complete cache busting features, and prepare v0.5.3 release.
+
+## Why
+- **Critical Bug**: Downstream reports session ID mismatch between console logs and actual WebSocket connection
+- **Stale bundle issues**: Browser/CDN caching serves old code versions
+- **Testing baseline needed**: Users need minimal test to validate setup
+- **Version verification**: No programmatic way to check loaded bundle version
+
+## What
+1. **PRIORITY**: Investigate and fix session ID regeneration bug
+2. Finalize cache busting with versioned bundles
+3. Add runtime version checking capabilities
+4. Provide minimal end-to-end test in deployment
+5. Update to version 0.5.3
+
+### Success Criteria
+- [ ] Session ID bug fixed - console logs match actual WebSocket URL
+- [ ] Comprehensive logging added to trace session ID flow
+- [ ] Versioned bundle files created (web-ble-mock.bundle.v0.5.3.js)
+- [ ] WebBleMock.version returns "0.5.3"
+- [ ] Minimal test HTML included in npm package
+- [ ] All tests pass with no session mismatches
+
+## All Needed Context
+
+### Session ID Bug Analysis
+```yaml
+# The Bug Report
+- Console shows: "[MockBluetooth] Reusing stored session: 127.0.0.1-chrome-524F"
+- Server receives: "New WebSocket connection for session: 127.0.0.1-chrome-9ZN4"
+- Downstream concern: "appears to be at a lower level than local storage"
+- Location: "Somewhere between url generation and actual connection to websocket"
+
+# Session ID Flow (Current Implementation)
+1. MockBluetooth constructor
+   - If no sessionId in bleConfig, calls generateAutoSessionId()
+   - Stores in this.autoSessionId
+
+2. requestDevice() 
+   - Creates effectiveConfig with sessionId || autoSessionId
+   - Passes to MockBluetoothDevice constructor
+
+3. MockBluetoothDevice constructor
+   - Stores bleConfig including sessionId
+   - Creates WebSocketTransport instance
+
+4. connect() in MockBluetoothRemoteGATTServer
+   - Maps bleConfig.sessionId to connectOptions.session (lines 185-186)
+   - Logs: "[MockGATT] Using session ID for WebSocket: {sessionId}"
+   - Calls transport.connect(connectOptions)
+
+5. WebSocketTransport.connect()
+   - Adds session to URL searchParams if provided
+   - Creates WebSocket with url.toString()
+
+# Potential Bug Locations
+- Multiple injectWebBluetoothMock calls creating new MockBluetooth instances
+- URL modification after construction but before WebSocket creation
+- Race condition between localStorage read and WebSocket connection
+- Session parameter not properly passed through layers
+```
+
+### Critical Code References
+```yaml
+# Session ID Generation and Persistence
+- file: src/mock-bluetooth.ts
+  lines: 376-412
+  function: generateAutoSessionId()
+  critical: Reads from localStorage, generates new if not found
+
+- file: src/mock-bluetooth.ts  
+  lines: 184-193
+  function: connect() mapping sessionId
+  critical: Maps sessionId to session, logs the mapping
+
+- file: src/ws-transport.ts
+  lines: 43-48
+  function: connect() URL construction
+  critical: Adds session param to URL, creates WebSocket
+
+# Uncommitted Changes
+- scripts/build-browser-bundle.js        # Cache busting implementation
+- src/mock-browser-entry.ts             # Version export (hardcoded 0.5.2)
+- src/mock-bluetooth.ts                 # getBundleVersion() function
+- tests/e2e/cache-busting.spec.ts      # Cache busting tests
+- tests/e2e/session-bug-repro.spec.ts   # Session bug reproduction
+```
+
+### Known Issues and Gotchas
+```typescript
+// CRITICAL BUG: Session ID might be regenerated between logging and connection
+// Need to add logging at WebSocket URL construction point
+
+// GOTCHA: injectWebBluetoothMock creates NEW MockBluetooth instance
+// Each injection generates new autoSessionId if called without explicit session
+
+// GOTCHA: localStorage blocked in about:blank context
+// Tests must use HTTP context for session persistence
+
+// IMPORTANT: Console logs may not reflect actual WebSocket URL
+// Need to log the EXACT URL passed to new WebSocket()
+```
+
+## Implementation Blueprint
+
+### Task Order for Bug Investigation and Fixes
+
+```yaml
+Task 1: Add comprehensive logging for session ID tracking
+MODIFY src/ws-transport.ts:
+  - BEFORE line 48: this.ws = new WebSocket(url.toString());
+  - ADD: console.log(`[WebSocketTransport] Connecting to: ${url.toString()}`);
+  - ADD: console.log(`[WebSocketTransport] Session parameter: ${options?.session || 'none'}`);
+  - This will show EXACTLY what URL is used for WebSocket
+
+Task 2: Add session ID validation in MockBluetooth
+MODIFY src/mock-bluetooth.ts:
+  - IN requestDevice() after effectiveConfig creation
+  - ADD: console.log(`[MockBluetooth] requestDevice using session: ${effectiveConfig.sessionId}`);
+  - IN MockBluetooth constructor after autoSessionId generation
+  - ADD property to track if this is a re-injection
+
+Task 3: Create comprehensive session tracking test
+CREATE tests/integration/session-id-tracking.test.ts:
+  - Test single injection flow
+  - Test multiple injection flow
+  - Capture ALL console logs
+  - Compare localStorage session vs WebSocket URL session
+  - Use MCP tools to verify server-side session
+
+Task 4: Fix the session ID bug (based on findings)
+POTENTIAL FIXES:
+  - Option 1: Prevent multiple MockBluetooth instances
+    - Store global reference to prevent re-creation
+    - Check if navigator.bluetooth already exists
+  
+  - Option 2: Ensure WebSocketTransport uses correct session
+    - Add validation that session in URL matches expected
+    - Log warning if mismatch detected
+  
+  - Option 3: Make session ID immutable once set
+    - Prevent regeneration on subsequent calls
+    - Use singleton pattern for session management
+
+Task 5: Update version to 0.5.3
+MODIFY package.json:
+  - FIND: "version": "0.5.2"
+  - REPLACE: "version": "0.5.3"
+
+Task 6: Update hardcoded version
+MODIFY src/mock-browser-entry.ts:
+  - FIND: version: '0.5.2'
+  - REPLACE: version: '0.5.3'
+
+Task 7: Create minimal E2E test with session validation
+CREATE examples/minimal-e2e-test.html:
+  - Test bundle loading and version
+  - Test session persistence with validation
+  - Capture WebSocket URL from logs
+  - Compare logged session vs URL session
+  - Clear pass/fail indication
+
+Task 8: Update package.json to include test file
+MODIFY package.json:
+  - ADD to "files" array: "examples/minimal-e2e-test.html"
+
+Task 9: Run comprehensive validation
+  - Build and test with new logging
+  - Verify session IDs match throughout flow
+  - Test with downstream reproduction scenario
+  - Use MCP tools to verify server-side behavior
+```
+
+### Debugging Implementation
+```typescript
+// Enhanced logging for session tracking
+class WebSocketTransport {
+  async connect(options?: { session?: string; /* ... */ }): Promise<void> {
+    const url = new URL(this.serverUrl);
+    // ... add parameters ...
+    
+    if (options?.session) {
+      url.searchParams.set('session', options.session);
+      this.sessionId = options.session;
+      console.log(`[WebSocketTransport] Session added to URL: ${options.session}`);
+    } else {
+      console.warn(`[WebSocketTransport] No session provided in options`);
+    }
+    
+    const finalUrl = url.toString();
+    console.log(`[WebSocketTransport] Final WebSocket URL: ${finalUrl}`);
+    
+    this.ws = new WebSocket(finalUrl);
+    // ...
+  }
+}
+
+// Session validation in mock
+class MockBluetooth {
+  private static instances = new Map<string, MockBluetooth>();
+  
+  constructor(serverUrl?: string, bleConfig?: any) {
+    // Check for existing instance
+    const key = serverUrl || 'default';
+    if (MockBluetooth.instances.has(key)) {
+      console.warn(`[MockBluetooth] Reusing existing instance for ${key}`);
+      return MockBluetooth.instances.get(key)!;
+    }
+    
+    // ... rest of constructor ...
+    MockBluetooth.instances.set(key, this);
+  }
+}
+```
+
+### Minimal E2E Test Structure
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <title>BLE Mock E2E Test v0.5.3</title>
+    <style>
+        .pass { color: green; }
+        .fail { color: red; }
+        .log { font-family: monospace; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <h1>Session ID Validation Test</h1>
+    <div id="results"></div>
+    <pre id="logs"></pre>
+    
+    <script src="../dist/web-ble-mock.bundle.js"></script>
+    <script>
+        const logs = [];
+        const originalLog = console.log;
+        
+        // Capture all logs
+        console.log = function(...args) {
+            const message = args.join(' ');
+            logs.push(message);
+            document.getElementById('logs').textContent = logs.join('\n');
+            originalLog.apply(console, args);
+        };
+        
+        async function testSessionConsistency() {
+            const results = [];
+            
+            // Test 1: Initial injection
+            window.WebBleMock.clearStoredSession();
+            window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080', {
+                service: '9800',
+                write: '9900', 
+                notify: '9901'
+            });
+            
+            const sessionFromLogs = extractSessionFromLogs(logs, 'Generated new session:');
+            
+            // Test 2: Second injection (should reuse)
+            logs.length = 0;
+            window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080', {
+                service: '9800',
+                write: '9900',
+                notify: '9901'
+            });
+            
+            const reusedSession = extractSessionFromLogs(logs, 'Reusing stored session:');
+            const wsUrlSession = extractSessionFromLogs(logs, 'Final WebSocket URL:');
+            
+            results.push({
+                test: 'Session Consistency',
+                pass: reusedSession && wsUrlSession && reusedSession === extractSessionFromUrl(wsUrlSession),
+                detail: `Logged: ${reusedSession}, URL: ${wsUrlSession}`
+            });
+            
+            displayResults(results);
+        }
+        
+        function extractSessionFromLogs(logs, pattern) {
+            const log = logs.find(l => l.includes(pattern));
+            if (!log) return null;
+            const match = log.match(/session[=:]?\s*([A-Z0-9.-]+)/i);
+            return match ? match[1] : null;
+        }
+        
+        function extractSessionFromUrl(url) {
+            const match = url.match(/session=([^&]+)/);
+            return match ? match[1] : null;
+        }
+        
+        function displayResults(results) {
+            const div = document.getElementById('results');
+            div.innerHTML = results.map(r => 
+                `<div class="${r.pass ? 'pass' : 'fail'}">
+                    ${r.pass ? '✅' : '❌'} ${r.test}: ${r.detail}
+                </div>`
+            ).join('');
+        }
+        
+        window.addEventListener('DOMContentLoaded', testSessionConsistency);
+    </script>
+</body>
+</html>
+```
+
+## Validation Loop
+
+### Level 1: Syntax & Build
+```bash
+# Update version first
+sed -i 's/"version": "0.5.2"/"version": "0.5.3"/' package.json
+
+# Fix lint/type errors
+pnpm run lint
+pnpm run typecheck
+
+# Clean build
+rm -rf dist/
+pnpm run build
+
+# Verify logging added
+grep -n "Final WebSocket URL" dist/ws-transport.js
+# Expected: Match found with line number
+```
+
+### Level 2: Session ID Bug Verification
+```bash
+# Run the new session tracking test
+pnpm run test tests/integration/session-id-tracking.test.ts
+
+# Run session bug reproduction with new logging
+pnpm exec playwright test tests/e2e/session-bug-repro.spec.ts --reporter=list
+
+# Check logs for session consistency
+# Expected: Session in logs matches session in WebSocket URL
+```
+
+### Level 3: Integration Testing
+```bash
+# Start bridge server with MCP
+pnpm run start
+
+# In another terminal, run minimal E2E test
+cd examples && python3 -m http.server 8000
+
+# Open http://localhost:8000/minimal-e2e-test.html
+# Expected: Session Consistency test passes
+
+# Use MCP to verify server sees correct session
+# Check that multiple connections use same session
+```
+
+### Level 4: Downstream Validation
+```bash
+# Create test scenario matching downstream
+cat > test-downstream.js << 'EOF'
+// First page load
+window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+const device1 = await navigator.bluetooth.requestDevice({filters: [{namePrefix: 'CS108'}]});
+await device1.gatt.connect();
+console.log('First connection session:', device1.sessionId);
+await device1.gatt.disconnect();
+
+// Simulate page reload
+window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+const device2 = await navigator.bluetooth.requestDevice({filters: [{namePrefix: 'CS108'}]});
+await device2.gatt.connect();
+console.log('Second connection session:', device2.sessionId);
+EOF
+
+# Run and verify sessions match
+```
+
+## Final Validation Checklist
+- [ ] Session ID bug fixed - logs match WebSocket URL
+- [ ] WebSocketTransport logs final URL with session
+- [ ] MockBluetooth prevents duplicate instances
+- [ ] Version updated to 0.5.3 throughout
+- [ ] Versioned bundle created
+- [ ] Minimal E2E test validates session consistency
+- [ ] MCP tools confirm server receives consistent session
+- [ ] No lint/type errors
+- [ ] All tests pass
+- [ ] Downstream scenario validated
+
+## Anti-Patterns to Avoid
+- ❌ Don't assume console.log reflects actual behavior
+- ❌ Don't create multiple MockBluetooth instances
+- ❌ Don't skip WebSocket URL logging
+- ❌ Don't ignore the "lower level" nature of the bug
+- ❌ Don't test only in ideal conditions
+
+---
+
+**PRP Confidence Score: 9.5/10**
+
+This enhanced PRP specifically targets the session ID bug with comprehensive logging and validation. The bug appears to be between URL construction and WebSocket creation, and our logging will pinpoint exactly where the session changes.

--- a/prp/spec/session-manager-fixes.md
+++ b/prp/spec/session-manager-fixes.md
@@ -1,0 +1,12 @@
+## FEATURE:
+- Review uncommitted changes in working tree. You have already some preliminary attempts at these features and fixes. Please carefully review and make sure that those changes are appropriate, and bring them forward if they are
+- Add cache busting to the web mock bundle.
+- Add the ability to check the version of the web mock bundle from test code
+- Add a working minimal end to end test to the deployment bundle so that users can baseline their tests when they dont behave correctly
+
+## REPORTED BUG:
+- Server reports auto-generated session ID sent even though test browser console logging reports sending session id from local storage
+  - While this bug has been difficult to reproduce, I consistently saw it on my downstream project. We need to be 100% sure that our implementation does not do this
+
+## OTHER CONSIDERATIONS
+- This will be version 0.5.3 for NPM publishing

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { BridgeServer } from './bridge-server.js';
 export { NobleTransport } from './noble-transport.js';
 export type { BleConfig } from './noble-transport.js';
-export { injectWebBluetoothMock } from './mock-bluetooth.js';
+export { injectWebBluetoothMock, clearStoredSession, testSessionPersistence, getBundleVersion } from './mock-bluetooth.js';
 export { WebSocketTransport } from './ws-transport.js';
 export type { WSMessage } from './ws-transport.js';
 export { normalizeUuid } from './utils.js';

--- a/src/mock-browser-entry.ts
+++ b/src/mock-browser-entry.ts
@@ -1,15 +1,19 @@
 // Browser entry point that explicitly exports what we need
-import { MockBluetooth, injectWebBluetoothMock, updateMockConfig } from './mock-bluetooth.js';
+import { MockBluetooth, injectWebBluetoothMock, updateMockConfig, clearStoredSession, testSessionPersistence, getBundleVersion } from './mock-bluetooth.js';
 
 // Export as a global object with the functions we need
 export const WebBleMock = {
   MockBluetooth,
   injectWebBluetoothMock,
-  updateMockConfig
+  updateMockConfig,
+  clearStoredSession,
+  testSessionPersistence,
+  getBundleVersion,
+  version: '0.5.3' // Bundle version for cache-busting verification
 };
 
 // Also export individually for ES modules
-export { MockBluetooth, injectWebBluetoothMock, updateMockConfig };
+export { MockBluetooth, injectWebBluetoothMock, updateMockConfig, clearStoredSession, testSessionPersistence, getBundleVersion };
 
 // For IIFE builds, ensure global is set
 if (typeof window !== 'undefined') {

--- a/tests/e2e/cache-busting.spec.ts
+++ b/tests/e2e/cache-busting.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test.describe('Cache Busting', () => {
+  const projectRoot = path.resolve(__dirname, '../..');
+  const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf-8'));
+  const currentVersion = packageJson.version;
+
+  test('versioned bundle should exist and contain correct version', async ({ page }) => {
+    // Check that versioned bundle file exists
+    const versionedBundlePath = path.join(projectRoot, 'dist', `web-ble-mock.bundle.v${currentVersion}.js`);
+    expect(fs.existsSync(versionedBundlePath)).toBe(true);
+
+    // Load the bundle and check version property
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: versionedBundlePath });
+
+    // Check WebBleMock is loaded with correct version
+    const version = await page.evaluate(() => {
+      return (window as any).WebBleMock?.version;
+    });
+    expect(version).toBe(currentVersion);
+
+    // Check getBundleVersion function
+    const bundleVersion = await page.evaluate(() => {
+      return (window as any).WebBleMock?.getBundleVersion?.();
+    });
+    expect(bundleVersion).toBe(currentVersion);
+  });
+
+  test('loading with timestamp query param should bypass cache', async ({ page }) => {
+    // Just load the bundle directly since we're testing cache-busting functionality
+    await page.goto('about:blank');
+    await page.addScriptTag({ 
+      path: path.join(projectRoot, 'dist', 'web-ble-mock.bundle.js'),
+      // Add a unique identifier to force reload
+      content: `// Cache bust: ${Date.now()}`
+    });
+
+    // Check version is present
+    const version = await page.evaluate(() => (window as any).WebBleMock?.version);
+    expect(version).toBe(currentVersion);
+  });
+
+  test('multiple loads with different timestamps should not conflict', async ({ page }) => {
+    await page.goto('about:blank');
+    
+    // First load
+    await page.addScriptTag({ 
+      path: path.join(projectRoot, 'dist', 'web-ble-mock.bundle.js')
+    });
+    const firstVersion = await page.evaluate(() => (window as any).WebBleMock?.version);
+
+    // Navigate to new blank page to simulate fresh load
+    await page.goto('about:blank');
+    
+    // Second load
+    await page.addScriptTag({ 
+      path: path.join(projectRoot, 'dist', 'web-ble-mock.bundle.js')
+    });
+    const secondVersion = await page.evaluate(() => (window as any).WebBleMock?.version);
+
+    // Both loads should have the same version
+    expect(firstVersion).toBe(currentVersion);
+    expect(secondVersion).toBe(currentVersion);
+  });
+
+  test('version mismatch detection', async ({ page }) => {
+    await page.goto('about:blank');
+
+    // Load bundle
+    await page.addScriptTag({ path: path.join(projectRoot, 'dist', 'web-ble-mock.bundle.js') });
+
+    // Simulate version mismatch scenario
+    const mismatchResult = await page.evaluate((expectedVersion) => {
+      const loadedVersion = (window as any).WebBleMock?.version;
+      return {
+        loaded: loadedVersion,
+        expected: expectedVersion,
+        matches: loadedVersion === expectedVersion
+      };
+    }, '99.99.99'); // Fake version to force mismatch
+
+    expect(mismatchResult.loaded).toBe(currentVersion);
+    expect(mismatchResult.expected).toBe('99.99.99');
+    expect(mismatchResult.matches).toBe(false);
+  });
+
+  test('version check example page functions correctly', async ({ page }) => {
+    // Use file:// URL to load the example
+    const examplePath = `file://${path.join(projectRoot, 'examples', 'version-check.html')}`;
+    await page.goto(examplePath);
+
+    // Wait for page to load
+    await page.waitForSelector('h1');
+
+    // Test loading versioned bundle
+    await page.click('button:has-text("Load Versioned Bundle")');
+    await page.waitForTimeout(500);
+
+    // Check success message appears
+    const successMessage = await page.textContent('.success');
+    expect(successMessage).toContain('Loaded versioned bundle');
+
+    // Test version check
+    await page.click('button:has-text("Check Version")');
+    await page.waitForTimeout(100);
+
+    // Verify version info is displayed
+    const output = await page.textContent('#output');
+    expect(output).toContain('WebBleMock loaded');
+    expect(output).toContain(`Bundle version: ${currentVersion}`);
+    expect(output).toContain('Version matches expected');
+  });
+
+  test('cache busting with random query prevents stale loads', async ({ page, context }) => {
+    // Create two pages to simulate different sessions
+    const page1 = await context.newPage();
+    const page2 = await context.newPage();
+
+    // Load bundle in both pages
+    await page1.goto('about:blank');
+    await page1.addScriptTag({ 
+      path: path.join(projectRoot, 'dist', 'web-ble-mock.bundle.js')
+    });
+
+    await page2.goto('about:blank'); 
+    await page2.addScriptTag({ 
+      path: path.join(projectRoot, 'dist', 'web-ble-mock.bundle.js')
+    });
+
+    // Check versions
+    const version1 = await page1.evaluate(() => (window as any).WebBleMock?.version);
+    const version2 = await page2.evaluate(() => (window as any).WebBleMock?.version);
+
+    expect(version1).toBe(currentVersion);
+    expect(version2).toBe(currentVersion);
+
+    await page1.close();
+    await page2.close();
+  });
+});

--- a/tests/e2e/session-bug-repro.spec.ts
+++ b/tests/e2e/session-bug-repro.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Reproduces the exact bug downstream is seeing:
+ * - Console logs show "Reusing stored session: 127.0.0.1-chrome-524F"
+ * - But WebSocket connects with different session "127.0.0.1-chrome-9ZN4"
+ */
+test.describe('Session Persistence Bug Reproduction', () => {
+  const bundlePath = path.join(__dirname, '../../dist/web-ble-mock.bundle.js');
+
+  test('localStorage session should be used for WebSocket connection', async ({ page }) => {
+    // Enable console logging
+    const consoleLogs: string[] = [];
+    page.on('console', (msg) => {
+      consoleLogs.push(msg.text());
+    });
+
+    // Start a local server to serve the bundle
+    await page.route('**/*', async route => {
+      const url = route.request().url();
+      if (url.endsWith('/bundle.js')) {
+        await route.fulfill({
+          path: bundlePath,
+          contentType: 'application/javascript',
+        });
+      } else {
+        await route.fulfill({
+          body: '<html><body>Test Page</body></html>',
+          contentType: 'text/html',
+        });
+      }
+    });
+
+    // First test - establish session
+    await page.goto('http://localhost/test1');
+    await page.addScriptTag({ url: '/bundle.js' });
+
+    const firstResult = await page.evaluate(async () => {
+      // Clear any existing session
+      window.WebBleMock.clearStoredSession();
+      
+      // Inject mock without explicit session
+      window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080', {
+        service: '9800',
+        write: '9900',
+        notify: '9901'
+      });
+      
+      // Get auto-generated session from the mock
+      const bluetooth = (navigator as any).bluetooth;
+      const autoSessionId = bluetooth.autoSessionId;
+      console.log(`[Test] First injection auto-session: ${autoSessionId}`);
+      
+      // Request device and connect
+      try {
+        const device = await navigator.bluetooth.requestDevice({
+          filters: [{ namePrefix: 'CS108' }]
+        });
+        
+        await device.gatt.connect();
+        
+        // Check what session was actually used
+        const transportSession = device.transport?.sessionId;
+        console.log(`[Test] First connection transport session: ${transportSession}`);
+        
+        await device.gatt.disconnect();
+        
+        return {
+          autoSessionId,
+          transportSession,
+          sessionIdFromDevice: device.sessionId
+        };
+      } catch (error) {
+        return { error: (error as Error).message };
+      }
+    });
+
+    console.log('First test result:', firstResult);
+    console.log('Console logs from first test:', consoleLogs);
+
+    // Clear logs for second test
+    consoleLogs.length = 0;
+
+    // Second test - should reuse session
+    await page.goto('http://localhost/test2');
+    await page.addScriptTag({ url: '/bundle.js' });
+
+    const secondResult = await page.evaluate(async () => {
+      // Inject mock again (should reuse localStorage session)
+      window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080', {
+        service: '9800',
+        write: '9900',
+        notify: '9901'
+      });
+      
+      // Get session from the mock
+      const bluetooth = (navigator as any).bluetooth;
+      const autoSessionId = bluetooth.autoSessionId;
+      console.log(`[Test] Second injection auto-session: ${autoSessionId}`);
+      
+      // Check localStorage directly
+      const storedSession = localStorage.getItem('ble-mock-session-id');
+      console.log(`[Test] localStorage session: ${storedSession}`);
+      
+      // Request device and try to connect
+      try {
+        const device = await navigator.bluetooth.requestDevice({
+          filters: [{ namePrefix: 'CS108' }]
+        });
+        
+        // Log the device's config
+        console.log(`[Test] Device bleConfig:`, JSON.stringify(device.bleConfig));
+        
+        await device.gatt.connect();
+        
+        // Check what session was actually used
+        const transportSession = device.transport?.sessionId;
+        console.log(`[Test] Second connection transport session: ${transportSession}`);
+        
+        return {
+          autoSessionId,
+          storedSession,
+          transportSession,
+          sessionIdFromDevice: device.sessionId,
+          deviceBleConfig: device.bleConfig
+        };
+      } catch (error) {
+        return { 
+          error: (error as Error).message,
+          autoSessionId,
+          storedSession
+        };
+      }
+    });
+
+    console.log('Second test result:', secondResult);
+    console.log('Console logs from second test:', consoleLogs);
+
+    // Analyze the bug
+    if (!firstResult.error && !secondResult.error) {
+      // Check if sessions match
+      expect(secondResult.autoSessionId).toBe(firstResult.autoSessionId);
+      expect(secondResult.storedSession).toBe(firstResult.autoSessionId);
+      
+      // This is where the bug occurs - transport session doesn't match
+      if (secondResult.transportSession !== secondResult.autoSessionId) {
+        console.error('BUG CONFIRMED: Transport session does not match auto-generated session!');
+        console.error(`Auto session: ${secondResult.autoSessionId}`);
+        console.error(`Transport session: ${secondResult.transportSession}`);
+      }
+    }
+
+    // Look for the specific log pattern downstream reported
+    const reusingLog = consoleLogs.find(log => log.includes('Reusing stored session'));
+    if (reusingLog) {
+      console.log('Found reusing log:', reusingLog);
+      // Extract the session ID from the log
+      const match = reusingLog.match(/Reusing stored session: (.+)/);
+      if (match) {
+        const loggedSession = match[1];
+        console.log(`Session from log: ${loggedSession}`);
+        console.log(`Session used in WebSocket: ${secondResult.transportSession || 'unknown'}`);
+        
+        // Check if they match
+        if (secondResult.transportSession && loggedSession !== secondResult.transportSession) {
+          console.error('CONFIRMED: Logged session does not match WebSocket session!');
+        }
+      }
+    }
+  });
+});

--- a/tests/e2e/session-persistence-bug.spec.ts
+++ b/tests/e2e/session-persistence-bug.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test.describe('Session Persistence Bug Reproduction', () => {
+  test('should maintain same session ID across page reloads', async ({ page }) => {
+    // Use a simple HTTP server URL or file:// protocol
+    const htmlPath = join(__dirname, '../../examples/minimal-session-repro.html');
+    await page.goto(`file://${htmlPath}`);
+    
+    // Enable console logging
+    page.on('console', msg => {
+      console.log(`[Browser Console] ${msg.text()}`);
+    });
+    
+    // Wait for page to load
+    await page.waitForLoadState('domcontentloaded');
+    
+    // Step 1: Inject mock
+    await page.click('#inject');
+    await page.waitForTimeout(500);
+    
+    // Step 2: Show session info
+    await page.click('#showSession');
+    await page.waitForTimeout(500);
+    
+    // Get the session ID from the log
+    const firstSessionLog = await page.locator('#log').textContent();
+    const firstSessionMatch = firstSessionLog?.match(/localStorage\['ble-mock-session-id'\]: ([\w\.-]+)/);
+    const firstSessionId = firstSessionMatch?.[1];
+    console.log('First session ID:', firstSessionId);
+    
+    // Step 3: Connect
+    await page.click('#connect');
+    await page.waitForTimeout(2000);
+    
+    // Get WebSocket session from log
+    const firstConnectLog = await page.locator('#log').textContent();
+    const firstWsMatch = firstConnectLog?.match(/WebSocket URL session parameter: ([\w\.-]+)/);
+    const firstWsSession = firstWsMatch?.[1];
+    console.log('First WebSocket session:', firstWsSession);
+    
+    // Step 4: Reload page
+    console.log('\n--- Reloading page ---\n');
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    
+    // Check if session persisted (may not have the message div)
+    try {
+      const reloadMessage = await page.locator('body > div.success, body > div.info').first().textContent({ timeout: 2000 });
+      console.log('After reload message:', reloadMessage);
+    } catch {
+      console.log('No reload message found');
+    }
+    
+    // Step 5: Inject mock again
+    await page.click('#inject');
+    await page.waitForTimeout(500);
+    
+    // Step 6: Show session info again
+    await page.click('#showSession');
+    await page.waitForTimeout(500);
+    
+    // Get the session ID after reload
+    const secondSessionLog = await page.locator('#log').textContent();
+    const secondSessionMatch = secondSessionLog?.match(/localStorage\['ble-mock-session-id'\]: ([\w\.-]+)/);
+    const secondSessionId = secondSessionMatch?.[1];
+    console.log('Second session ID:', secondSessionId);
+    
+    // Step 7: Connect again
+    await page.click('#connect');
+    await page.waitForTimeout(2000);
+    
+    // Get WebSocket session from log
+    const secondConnectLog = await page.locator('#log').textContent();
+    // Find the last occurrence of WebSocket URL session parameter
+    const allWsMatches = [...secondConnectLog?.matchAll(/WebSocket URL session parameter: ([\w\.-]+)/g) || []];
+    const secondWsSession = allWsMatches[allWsMatches.length - 1]?.[1];
+    console.log('Second WebSocket session:', secondWsSession);
+    
+    // Check for bug
+    const bugDetected = await page.locator('#log').textContent();
+    const hasBug = bugDetected?.includes('🐛 BUG:');
+    
+    console.log('\n=== Test Results ===');
+    console.log('First session ID:', firstSessionId);
+    console.log('Second session ID:', secondSessionId);
+    console.log('First WebSocket session:', firstWsSession);
+    console.log('Second WebSocket session:', secondWsSession);
+    console.log('Bug detected?', hasBug);
+    
+    // Assertions
+    expect(firstSessionId).toBeTruthy();
+    expect(secondSessionId).toBeTruthy();
+    expect(firstSessionId).toBe(secondSessionId); // Should reuse same session
+    expect(firstWsSession).toBe(firstSessionId); // WebSocket should use stored session
+    expect(secondWsSession).toBe(secondSessionId); // WebSocket should use stored session
+    expect(hasBug).toBe(false); // Should not detect bug
+  });
+});

--- a/tests/e2e/simple-session-test.spec.ts
+++ b/tests/e2e/simple-session-test.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('session persistence across reload', async ({ page }) => {
+  const bundlePath = join(__dirname, '../../dist/web-ble-mock.bundle.js');
+  
+  // First page load - use HTTP to enable localStorage
+  await page.goto('http://localhost:8888/examples/minimal-session-repro.html');
+  
+  // Capture all console logs
+  const consoleLogs: string[] = [];
+  page.on('console', msg => {
+    const text = msg.text();
+    consoleLogs.push(text);
+    console.log(`[Browser] ${text}`);
+  });
+  
+  // First injection
+  const firstSession = await page.evaluate(() => {
+    window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+    const bluetooth = (navigator as any).bluetooth;
+    return {
+      autoSessionId: bluetooth.autoSessionId,
+      stored: localStorage.getItem('ble-mock-session-id')
+    };
+  });
+  
+  console.log('First injection:', firstSession);
+  
+  // Connect and capture WebSocket URL
+  const firstConnection = await page.evaluate(async () => {
+    let capturedUrl = '';
+    
+    // Override WebSocket to capture URL
+    const OriginalWebSocket = WebSocket;
+    (window as any).WebSocket = class extends OriginalWebSocket {
+      constructor(url: string, ...args: any[]) {
+        capturedUrl = url;
+        super(url, ...args);
+      }
+    };
+    
+    try {
+      const device = await navigator.bluetooth.requestDevice({
+        filters: [{ namePrefix: 'CS108' }]
+      });
+      await device.gatt.connect();
+      return { success: true, url: capturedUrl };
+    } catch (error: any) {
+      return { success: false, error: error.message, url: capturedUrl };
+    }
+  });
+  
+  console.log('First connection:', firstConnection);
+  
+  // Extract session from URL
+  const firstUrlSession = new URL(firstConnection.url).searchParams.get('session');
+  console.log('First WebSocket session:', firstUrlSession);
+  
+  // Reload page
+  console.log('\n--- Reloading page ---\n');
+  await page.reload();
+  
+  // Re-inject bundle after reload
+  await page.addScriptTag({ path: bundlePath });
+  
+  // Second injection
+  const secondSession = await page.evaluate(() => {
+    window.WebBleMock.injectWebBluetoothMock('ws://localhost:8080');
+    const bluetooth = (navigator as any).bluetooth;
+    return {
+      autoSessionId: bluetooth.autoSessionId,
+      stored: localStorage.getItem('ble-mock-session-id')
+    };
+  });
+  
+  console.log('Second injection:', secondSession);
+  
+  // Connect again and capture WebSocket URL
+  const secondConnection = await page.evaluate(async () => {
+    let capturedUrl = '';
+    
+    // Override WebSocket to capture URL
+    const OriginalWebSocket = WebSocket;
+    (window as any).WebSocket = class extends OriginalWebSocket {
+      constructor(url: string, ...args: any[]) {
+        capturedUrl = url;
+        super(url, ...args);
+      }
+    };
+    
+    try {
+      const device = await navigator.bluetooth.requestDevice({
+        filters: [{ namePrefix: 'CS108' }]
+      });
+      await device.gatt.connect();
+      return { success: true, url: capturedUrl };
+    } catch (error: any) {
+      return { success: false, error: error.message, url: capturedUrl };
+    }
+  });
+  
+  console.log('Second connection:', secondConnection);
+  
+  // Extract session from URL
+  const secondUrlSession = new URL(secondConnection.url).searchParams.get('session');
+  console.log('Second WebSocket session:', secondUrlSession);
+  
+  // Analysis
+  console.log('\n=== Session Persistence Analysis ===');
+  console.log('First session ID:', firstSession.autoSessionId);
+  console.log('Second session ID:', secondSession.autoSessionId);
+  console.log('First WebSocket session:', firstUrlSession);
+  console.log('Second WebSocket session:', secondUrlSession);
+  console.log('Sessions match?', firstUrlSession === secondUrlSession);
+  
+  // Check if we found the bug
+  const foundBug = firstSession.autoSessionId === secondSession.autoSessionId && 
+                   firstUrlSession !== secondUrlSession;
+  
+  if (foundBug) {
+    console.log('\n🐛 BUG REPRODUCED!');
+    console.log('localStorage shows session reused but WebSocket uses different session!');
+  } else {
+    console.log('\n✅ Session persistence working correctly');
+  }
+  
+  // Assertions
+  expect(firstSession.autoSessionId).toBe(secondSession.autoSessionId);
+  expect(firstUrlSession).toBe(secondUrlSession);
+});


### PR DESCRIPTION
## Summary
- Add cache busting functionality for web mock bundle to prevent stale cached versions
- Add version checking capability to verify loaded bundle version from test code
- Add comprehensive session persistence improvements with enhanced debugging

## Changes

### Cache Busting
- Build script now creates versioned bundles (e.g., `web-ble-mock.bundle.v0.5.3.js`)
- Version is embedded in bundle and accessible via `window.WebBleMock.version`
- Added `examples/version-check.html` for testing cache busting functionality

### Version Checking
- Added `getBundleVersion()` function to programmatically check bundle version
- Added `testSessionPersistence()` function for debugging localStorage issues
- Exported these functions in the browser bundle for test access

### Session Persistence Improvements
- Enhanced logging throughout session ID flow to help diagnose regeneration issues
- Added localStorage availability and context logging
- Added WebSocket connection parameter logging
- Created comprehensive test examples for reproducing and debugging session issues

### Test Examples
- `examples/minimal-session-repro.html` - comprehensive session persistence test
- `examples/version-check.html` - cache busting verification
- `examples/README.md` - documentation for all examples
- Multiple E2E tests for session persistence scenarios

## Test Plan
- [x] Run `pnpm run lint` - 3 warnings (unused variables)
- [x] Run `pnpm run typecheck` - no errors
- [x] Run `pnpm run build` - builds successfully with v0.5.3
- [ ] Test cache busting with `examples/version-check.html`
- [ ] Test session persistence with `examples/minimal-session-repro.html`
- [ ] Run full test suite before publishing

## Version
This PR bumps the version to **0.5.3** for NPM publishing.

🤖 Generated with [Claude Code](https://claude.ai/code)