### PR TITLE
fix: dynamic version in mock-browser-entry for v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.9] - 2025-08-05
+
+### Fixed
+- **Mock Browser Entry Version**: Fixed hardcoded version in mock-browser-entry.ts
+  - Version now uses build-time replacement like other modules
+  - Ensures WebBleMock.version correctly reflects package version
+  - Fixes version mismatch in bundled output
+
 ## [0.5.8] - 2025-08-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-mcp-test",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Complete BLE testing stack: WebSocket bridge server, MCP observability layer, and Web Bluetooth API mock. Test real BLE devices in Playwright/E2E tests without browser support.",
   "keywords": [
     "mcp",

--- a/src/mock-browser-entry.ts
+++ b/src/mock-browser-entry.ts
@@ -7,7 +7,8 @@ export const WebBleMock = {
   injectWebBluetoothMock,
   updateMockConfig,
   getBundleVersion,
-  version: '0.5.7' // Bundle version for cache-busting verification
+  // Version will be replaced at build time by build script
+  version: typeof __PACKAGE_VERSION__ !== 'undefined' ? __PACKAGE_VERSION__ : 'dev'
 };
 
 // Also export individually for ES modules


### PR DESCRIPTION
## Summary
Fix hardcoded version in mock-browser-entry.ts that was causing version mismatches in the bundled output.

## Problem
The client app reported that the bundle showed `version: "0.5.7"` on line 601 even after installing v0.5.8. This was due to a hardcoded version string in mock-browser-entry.ts that wasn't being updated dynamically.

## Solution
- Replace hardcoded version with build-time substitution using `__PACKAGE_VERSION__`
- The build script already defines this constant, so it works seamlessly
- Now `WebBleMock.version` correctly reflects the package.json version

## Changes
- Updated `src/mock-browser-entry.ts` to use dynamic version
- Added v0.5.9 changelog entry
- Bumped version to 0.5.9

## Test Plan
After building:
```bash
grep -n "version.*0.5" dist/web-ble-mock.bundle.js
```
Shows:
- Line 31: `version = "0.5.9"` (for _mv parameter)
- Line 602: `version: true ? "0.5.9" : "dev"` (fixed\!)
- Line 611: `window.WebBleMock.version = '0.5.9'`

The mock will now correctly report its version to the bridge server via the `_mv` parameter.

🤖 Generated with [Claude Code](https://claude.ai/code)